### PR TITLE
Don't reload embed.js.

### DIFF
--- a/lib/disqus-thread.js
+++ b/lib/disqus-thread.js
@@ -89,7 +89,11 @@ module.exports = React.createClass({
   },
 
   componentDidMount: function () {
-    this.addDisqusScript();
+    if (typeof DISQUS !== "undefined") {
+      DISQUS.reset({reload: true});
+    } else {
+      this.addDisqusScript();
+    }
   },
 
   componentWillUnmount: function () {


### PR DESCRIPTION
This commit allows you to unload a Disqus thread and then load a new
one.
