### PR TITLE
Fixes for React 0.13.x

### DIFF
--- a/lib/disqus-thread.js
+++ b/lib/disqus-thread.js
@@ -89,6 +89,14 @@ module.exports = React.createClass({
   },
 
   componentDidMount: function () {
+    DISQUS_CONFIG
+      .filter(function (prop) {
+        return !!this.props[camelCase(prop)];
+      }, this).
+      forEach(function(prop) {
+        window['disqus_' + prop] = this.props[camelCase(prop)];
+      }, this);
+
     if (typeof DISQUS !== "undefined") {
       DISQUS.reset({reload: true});
     } else {
@@ -101,21 +109,8 @@ module.exports = React.createClass({
   },
 
   render: function () {
-    // Prep Disqus configuration variables
-    var disqusVars = DISQUS_CONFIG
-      .filter(function (prop) {
-        return !!this.props[camelCase(prop)];
-      }, this)
-      .map(function (prop) {
-        return 'var disqus_' + prop + ' = \'' +
-                this.props[camelCase(prop)].replace('\'', '\\\'') +
-               '\';';
-      }, this)
-      .join('');
-
     return <div {...this.props} >
       <div id="disqus_thread"></div>
-      <script dangerouslySetInnerHTML={{__html: disqusVars}}></script>
       <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
       <a href="http://disqus.com" className="dsq-brlink">blog comments powered by <span className="logo-disqus">Disqus</span></a>
     </div>;

--- a/lib/disqus-thread.js
+++ b/lib/disqus-thread.js
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var React = require('react');
 var DISQUS_CONFIG = [
   'shortname', 'identifier', 'title', 'url', 'category_id'

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/mzabriskie/react-disqus-thread",
   "dependencies": {
-    "react": "^0.12.0"
+    "react": "0.12.x - 1.x"
   },
   "devDependencies": {
     "jsx-loader": "^0.12",


### PR DESCRIPTION
I tried your component on React 0.13.1, and the injected script to set the `disqus_` variables doesn't run. I'm not sure whether it used to work in older versions; this thread says that setting `innerHTML` on a `<script>` element does not cause the scripts to run: https://github.com/facebook/react/issues/654.

In any case, it seems cleaner to me to simply set the variables in `componentDidMount`.