### PR TITLE
Fixed "main" attribute in bower.json to point to react-disqus-thread.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ http://mzabriskie.github.io/react-disqus-thread/example
 
 ```js
 var React = require('react');
-var DisqusThread = require('react-disqus-thread');
+var ReactDisqusThread = require('react-disqus-thread');
 
 var App = createClass({
 	render: function () {
 		return (
-			<DisqusThread
+			<ReactDisqusThread
 				shortname="example"
 				identifier="something-unique-12345"
 				title="Example Thread"

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Matt Zabriskie"
   ],
   "description": "React Disqus thread component",
-  "main": "./dist/disqus-thread.js",
+  "main": "./dist/react-disqus-thread.js",
   "keywords": [
     "disqus",
     "react",


### PR DESCRIPTION
…js, and changed the example component name to ReactDisuqsThread to match the global component name that Bower will return