### PR TITLE
Reload disqus when invoking `componentDidUpdate`

### DIFF
--- a/lib/disqus-thread.js
+++ b/lib/disqus-thread.js
@@ -69,6 +69,10 @@ module.exports = React.createClass({
   },
 
   addDisqusScript: function () {
+    if(window._disqusAdded) {
+      return;
+    }
+
     var child = this.disqus = document.createElement('script');
     var parent = document.getElementsByTagName('head')[0] ||
                  document.getElementsByTagName('body')[0];
@@ -78,6 +82,7 @@ module.exports = React.createClass({
     child.src = '//' + this.props.shortname + '.disqus.com/embed.js';
 
     parent.appendChild(child);
+    window._disqusAdded = true;
   },
 
   removeDisqusScript: function () {
@@ -87,7 +92,15 @@ module.exports = React.createClass({
     }
   },
 
+  componentDidUpdate: function () {
+    this.loadDisqus();
+  },
+
   componentDidMount: function () {
+    this.loadDisqus();
+  },
+
+  loadDisqus: function() {
     DISQUS_CONFIG
       .filter(function (prop) {
         return !!this.props[camelCase(prop)];


### PR DESCRIPTION
Sometimes when browsing though a set of article, (like using a sidebar) our component get updated.
So, we need to show a different comment box. But it does not do it.

Here's the fix.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mzabriskie/react-disqus-thread/9)
<!-- Reviewable:end -->
