### PR TITLE
Remove URL hashbang code

### DIFF
--- a/lib/components/DisqusThread.js
+++ b/lib/components/DisqusThread.js
@@ -151,9 +151,6 @@ module.exports = React.createClass({
         reload: true,
         config: function config() {
           copyProps(this.page, props);
-
-          // Disqus needs hashbang URL, see https://help.disqus.com/customer/portal/articles/472107
-          this.page.url = this.page.url.replace(/#/, '') + '#!newthread';
         }
       });
     } else { // Otherwise add Disqus to the page


### PR DESCRIPTION
Hash bangs are not required, and appending `#!newthread` to the end of the URL causes Disqus to create a new thread.
E.g. 
Disqus treats these two separately. `example.com/1` and `example.com/1#!newthread`

Example:
https://github.com/disqus/DISQUS-API-Recipes/blob/master/snippets/js/disqus-reset/disqus_reset.html#L8

