### PR TITLE
Fix missing space.

### DIFF
--- a/lib/components/DisqusThread.js
+++ b/lib/components/DisqusThread.js
@@ -106,8 +106,7 @@ module.exports = React.createClass({
           </span>
         </noscript>
         <a href="http://disqus.com" className="dsq-brlink">
-          blog comments powered by
-          <span className="logo-disqus">Disqus</span>
+          Blog comments powered by <span className="logo-disqus">Disqus</span>.
         </a>
       </div>
     );


### PR DESCRIPTION
Was rendering as "blog comments powered byDisqus". Added a space after "by". Also added proper punctuation and capitalization, because why not..