### PR TITLE
Do not reload the disqus component unless the identifier changes

### DIFF
--- a/lib/components/DisqusThread.js
+++ b/lib/components/DisqusThread.js
@@ -87,12 +87,21 @@ module.exports = React.createClass({
     };
   },
 
+  getInitialState() {
+    return {};
+  },
+
   componentDidMount() {
+    this.state.identifier = this.props.identifier;
     this.loadDisqus();
   },
 
   componentDidUpdate() {
-    this.loadDisqus();
+    if (this.state.identifier != this.props.identifier)
+    {
+      this.state.identifier = this.props.identifier;
+      this.loadDisqus();
+    }
   },
 
   render() {


### PR DESCRIPTION
Do not reload the disqus component on componentDidUpdate() unless the identifier changes.
Without this change, any change in page store data can trigger a reload of the disqus component.

This change works on my machine when using the script as part of another solution. However, when I try build as part of the forked repo, I get this error on npm install :
No compatible version found: react@'>=0.14.0 <0.15.0'
