### PR TITLE
remove noscript tag to fix React 15 errors

### DIFF
--- a/lib/components/DisqusThread.js
+++ b/lib/components/DisqusThread.js
@@ -99,9 +99,6 @@ module.exports = React.createClass({
     return (
       <div>
         <div id="disqus_thread"/>
-        <a href="http://disqus.com" className="dsq-brlink">
-          Blog comments powered by <span className="logo-disqus">Disqus</span>.
-        </a>
       </div>
     );
   },

--- a/lib/components/DisqusThread.js
+++ b/lib/components/DisqusThread.js
@@ -97,7 +97,7 @@ module.exports = React.createClass({
 
   render() {
     return (
-      <div {...this.props}>
+      <div>
         <div id="disqus_thread"/>
         <a href="http://disqus.com" className="dsq-brlink">
           Blog comments powered by <span className="logo-disqus">Disqus</span>.

--- a/lib/components/DisqusThread.js
+++ b/lib/components/DisqusThread.js
@@ -99,12 +99,6 @@ module.exports = React.createClass({
     return (
       <div {...this.props}>
         <div id="disqus_thread"/>
-        <noscript>
-          <span>
-            Please enable JavaScript to view the
-            <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a>
-          </span>
-        </noscript>
         <a href="http://disqus.com" className="dsq-brlink">
           Blog comments powered by <span className="logo-disqus">Disqus</span>.
         </a>


### PR DESCRIPTION
The noscript tag causes invariant warnings in React 15.0.1 and errors in 15.1.x and newer when rendered on the server.  Since React no longer wraps tags in spans, the noscript tag is assigned a react-id value when it is rendered, but the browser ignores it causing React to think that it has lost one of the elements.

I don't there are many cases where a noscript tag is useful in a React app sinceJavaScript usually needs to be running for React to work? It should be okay to remove it?
