### PR TITLE
 Update DisqusThread to work with (non-beta) react 16

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 WaltzApp, all rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/components/DisqusThread.js
+++ b/lib/components/DisqusThread.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 const DISQUS_CONFIG = [
   'shortname', 'identifier', 'title', 'url', 'category_id', 'onNewComment'
 ];
@@ -24,14 +25,14 @@ module.exports = React.createClass({
   displayName: 'DisqusThread',
 
   propTypes: {
-    id: React.PropTypes.string,
+    id: PropTypes.string,
 
     /**
      * `shortname` tells the Disqus service your forum's shortname,
      * which is the unique identifier for your website as registered
      * on Disqus. If undefined , the Disqus embed will not load.
      */
-    shortname: React.PropTypes.string.isRequired,
+    shortname: PropTypes.string.isRequired,
 
     /**
      * `identifier` tells the Disqus service how to identify the
@@ -42,7 +43,7 @@ module.exports = React.createClass({
      * domains, so we recommend using your own unique way of
      * identifying a thread.
      */
-    identifier: React.PropTypes.string,
+    identifier: PropTypes.string,
 
     /**
      * `title` tells the Disqus service the title of the current page.
@@ -50,7 +51,7 @@ module.exports = React.createClass({
      * If undefined, Disqus will use the <title> attribute of the page.
      * If that attribute could not be used, Disqus will use the URL of the page.
      */
-    title: React.PropTypes.string,
+    title: PropTypes.string,
 
     /**
      * `url` tells the Disqus service the URL of the current page.
@@ -59,21 +60,21 @@ module.exports = React.createClass({
      * is undefined. In addition, this URL is always saved when a thread is
      * being created so that Disqus knows what page a thread belongs to.
      */
-    url: React.PropTypes.string,
+    url: PropTypes.string,
 
     /**
      * `category_id` tells the Disqus service the category to be used for
      * the current page. This is used when creating the thread on Disqus
      * for the first time.
      */
-    category_id: React.PropTypes.string,
+    category_id: PropTypes.string,
 
     /**
      * `onNewComment` function accepts one parameter `comment` which is a
      * JavaScript object with comment `id` and `text`. This allows you to track
      * user comments and replies and run a script after a comment is posted.
      */
-    onNewComment: React.PropTypes.func
+    onNewComment: PropTypes.func
   },
 
   getDefaultProps() {

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   "homepage": "https://github.com/mzabriskie/react-disqus-thread",
   "peerDependencies": {
     "prop-types": "^15.5.10",
-    "react": "^16.0.0-beta.1",
-    "react-dom": "^16.0.0-beta.1"
+    "react": "^16.1.0",
+    "react-dom": "^16.1.0"
   },
   "devDependencies": {
     "rackt-cli": "^0.5.3",
-    "react": "^16.0.0-beta.1",
-    "react-dom": "^16.0.0-beta.1"
+    "react": "^16.1.0",
+    "react-dom": "^16.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,12 +23,13 @@
   },
   "homepage": "https://github.com/mzabriskie/react-disqus-thread",
   "peerDependencies": {
-    "react": "^15.0.1",
-    "react-dom": "^15.0.1"
+    "prop-types": "^15.5.10",
+    "react": "^16.0.0-beta.1",
+    "react-dom": "^16.0.0-beta.1"
   },
   "devDependencies": {
     "rackt-cli": "^0.5.3",
-    "react": "^15.0.1",
-    "react-dom": "^15.0.1"
+    "react": "^16.0.0-beta.1",
+    "react-dom": "^16.0.0-beta.1"
   }
 }


### PR DESCRIPTION
This PR is similar to https://github.com/mzabriskie/react-disqus-thread/pull/34 but it points to non-beta versions of react and react-dom